### PR TITLE
Fix README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,5 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
-# Nexq-web
-# Nexq-web
-# Nexq-web
+
+For the latest updates, visit the project on GitHub.


### PR DESCRIPTION
## Summary
- clean up trailing lines in README
- note that updates are on GitHub

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b0b3a3b48332a74878a5df3122e1