### PR TITLE
Fix AOS initialization

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,8 +14,6 @@ export class AppComponent implements OnInit, AfterViewInit {
   title = 'nexq-ai';
 
 
-  constructor(@Inject(PLATFORM_ID) private platformId: any) {}
-
   constructor(
     @Inject(PLATFORM_ID) private platformId: any,
     private aos: AosService

--- a/src/app/features/features.component.ts
+++ b/src/app/features/features.component.ts
@@ -66,7 +66,6 @@ export class FeaturesComponent implements OnInit, AfterViewInit, OnDestroy {
   private isBrowser: boolean;
   
   constructor(
-    @Inject(PLATFORM_ID) private platformId: Object
     @Inject(PLATFORM_ID) private platformId: Object,
     private aos: AosService
   ) {

--- a/src/index.html
+++ b/src/index.html
@@ -6,19 +6,8 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" rel="stylesheet">
 </head>
 <body>
   <app-root></app-root>
-
-  <script src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
-  <script>
-    AOS.init({
-      duration: 800,
-      easing: 'ease-out-cubic',
-      once: true
-    });
-  </script>
-
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix duplicated constructors that broke build
- remove redundant AOS CDN from `index.html`
- keep initialization via `AosService`

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6840f358916483328e4f65bb3bbbd56d