### PR TITLE
feat: optimize mobile rendering

### DIFF
--- a/src/app/about-us/about-us.component.scss
+++ b/src/app/about-us/about-us.component.scss
@@ -1130,3 +1130,20 @@
     }
   }
 }
+
+@media (max-width: 768px) {
+  .summary-card,
+  .differentiator-card,
+  .glass-card {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    box-shadow: none;
+    transition: none;
+  }
+
+  .summary-card:hover,
+  .differentiator-card:hover,
+  .glass-card:hover {
+    transform: none;
+  }
+}

--- a/src/app/about-us/about-us.component.ts
+++ b/src/app/about-us/about-us.component.ts
@@ -237,7 +237,9 @@ export class AboutUsComponent implements OnInit, AfterViewInit, OnDestroy {
   // =================== MODO INDEX ===================
   private initIndexMode(): void {
     this.addIndexModeClasses();
-    this.initBasicAnimations();
+    if (!this.isMobile) {
+      this.initBasicAnimations();
+    }
   }
 
   private addIndexModeClasses(): void {
@@ -253,9 +255,11 @@ export class AboutUsComponent implements OnInit, AfterViewInit, OnDestroy {
   // =================== MODO PÁGINA COMPLETA ===================
   private initFullPageMode(): void {
     this.addFullPageModeClasses();
-    this.initAdvancedAnimations();
-    this.initTeamSelector();
-    this.initInteractiveElements();
+    if (!this.isMobile) {
+      this.initAdvancedAnimations();
+      this.initTeamSelector();
+      this.initInteractiveElements();
+    }
   }
 
   private addFullPageModeClasses(): void {

--- a/src/app/contact/contact.component.scss
+++ b/src/app/contact/contact.component.scss
@@ -371,8 +371,19 @@
     padding: 0.75rem;
     font-size: 0.85rem;
   }
-  
+
   .error-message small {
     font-size: 0.75rem;
+  }
+
+  .contact-form-container,
+  .info-card {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    box-shadow: none;
+  }
+
+  .contact-form-container {
+    padding: 2rem 1.5rem;
   }
 }

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -637,6 +637,12 @@ $bounce-timing: cubic-bezier(0.68, -0.55, 0.265, 1.55);
     padding: 2rem 1.5rem;
     border-radius: 16px;
     // Misma inclinación en tablets
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    box-shadow:
+      0 10px 25px rgba(0, 0, 0, 0.25),
+      0 4px 10px rgba(94, 137, 176, 0.1),
+      inset 0 1px 0 rgba(255, 255, 255, 0.1);
   }
   
   .hero-title {
@@ -686,6 +692,12 @@ $bounce-timing: cubic-bezier(0.68, -0.55, 0.265, 1.55);
   .hero-content {
     padding: 1.5rem 1rem;
     // Misma inclinación en móviles
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow:
+      0 6px 20px rgba(0, 0, 0, 0.2),
+      0 2px 8px rgba(94, 137, 176, 0.1),
+      inset 0 1px 0 rgba(255, 255, 255, 0.05);
   }
   
   .hero-logo {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -46,6 +46,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   private mouseY = 0;
   private cursorTrail: HTMLElement[] = [];
   private isReducedMotion = false;
+  private hasFinePointer = false;
 
   constructor(
     @Inject(PLATFORM_ID) private platformId: Object,
@@ -60,6 +61,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     if (isPlatformBrowser(this.platformId)) {
       // Check for reduced motion preference
       this.isReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      this.hasFinePointer = window.matchMedia('(pointer: fine)').matches;
       
       // Initialize scroll position
       this.scroll.scrollToPosition([0, 0]);
@@ -87,8 +89,10 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
       // Initialize all animations with proper timing
       setTimeout(() => {
         this.initializeHeroAnimations();
-        this.setupAdvancedCursor();
-        this.setupFloatingElements();
+        if (this.hasFinePointer) {
+          this.setupAdvancedCursor();
+          this.setupFloatingElements();
+        }
       }, 100);
     }
     
@@ -132,7 +136,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
 
   @HostListener('window:mousemove', ['$event'])
   onMouseMove(event: MouseEvent): void {
-    if (!isPlatformBrowser(this.platformId) || this.isReducedMotion) return;
+    if (!isPlatformBrowser(this.platformId) || this.isReducedMotion || !this.hasFinePointer) return;
     
     this.mouseX = event.clientX;
     this.mouseY = event.clientY;
@@ -724,7 +728,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
   // }
 
   private setupFloatingElements(): void {
-    if (!isPlatformBrowser(this.platformId) || this.isReducedMotion) return;
+    if (!isPlatformBrowser(this.platformId) || this.isReducedMotion || !this.hasFinePointer) return;
 
     // Create floating geometric shapes
     for (let i = 0; i < 5; i++) {

--- a/src/app/services-overview/services-overview.component.html
+++ b/src/app/services-overview/services-overview.component.html
@@ -1,9 +1,9 @@
 <section class="services-section" [ngClass]="{'services-detail-view': mostrarServicio()}">
   <!-- Nodos neurales (solo visibles en vista detallada) -->
-  <app-particles-background
+  <app-particles-background *ngIf="showParticles"
     [opacity]="0.3"
     [particleColors]="particleColors"
-    [particleDensity]="mostrarServicio() ? 12000 : 8000"
+    [particleDensity]="particleDensity"
     [maxConnectDistance]="120"
     [particleSpeed]="0.6"
   ></app-particles-background>

--- a/src/app/services-overview/services-overview.component.scss
+++ b/src/app/services-overview/services-overview.component.scss
@@ -1151,7 +1151,7 @@ cense.
  * animation scale-up-top
  * ----------------------------------------
  */
- @keyframes scale-up-top {
+@keyframes scale-up-top {
   0% {
     transform: scale(0.5);
     transform-origin: 50% 0%;
@@ -1159,5 +1159,19 @@ cense.
   100% {
     transform: scale(1);
     transform-origin: 50% 0%;
+  }
+}
+
+@media (max-width: 768px) {
+  .service-card {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    box-shadow: none;
+    transition: none;
+  }
+
+  .service-card::before,
+  .service-card::after {
+    display: none;
   }
 }

--- a/src/app/services-overview/services-overview.component.ts
+++ b/src/app/services-overview/services-overview.component.ts
@@ -29,6 +29,12 @@ export class ServicesOverviewComponent implements OnInit, AfterViewInit {
     'rgba(94, 137, 176, 0.3)', // azul claro
     'rgba(255, 255, 255, 0.5)' // blanco
   ];
+  isMobile = false;
+  showParticles = true;
+
+  get particleDensity(): number {
+    return this.isMobile ? 20000 : (this.mostrarServicio() ? 12000 : 8000);
+  }
 
   constructor(
     private el: ElementRef,
@@ -43,9 +49,11 @@ export class ServicesOverviewComponent implements OnInit, AfterViewInit {
   ngOnInit(): void {
     this.mostrarServicio.set(this.serviceEstatus.getActivate());
     this.serviceEstatus.setActivate();
-    
+
     // Inicializar animaciones solo en el navegador
     if (isPlatformBrowser(this.platformId)) {
+      this.isMobile = window.innerWidth <= 768;
+      this.showParticles = !this.isMobile;
       this.initFadeInAnimations();
       this.aos.refresh();
     }


### PR DESCRIPTION
## Summary
- Skip heavy About Us animations on mobile and drop backdrop filters and hover effects for lightweight cards
- Guard Home page cursor and floating shapes behind fine pointer check and lighten hero blur on small screens
- Disable particle background and glass effects on services and contact cards for better mobile performance

## Testing
- `npm run lint` *(fails: 121 lint errors)*
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ad12feb0f48332a022e67e3bcac0ca