### PR TITLE
fix: ensure services CTA title is visible

### DIFF
--- a/src/app/services-overview/services-overview.component.html
+++ b/src/app/services-overview/services-overview.component.html
@@ -174,16 +174,14 @@
     </div>
     
     <!-- CTA Container - Versión diferente según el estado -->
-    <div class="cta-container" *ngIf="!mostrarServicio()" 
-         data-aos="fade-up" >
+    <div class="cta-container" *ngIf="!mostrarServicio()">
       <h3 class="cta-title">¿Necesitas una solución personalizada?</h3>
       <p class="cta-text">Contáctanos para recibir asesoría especializada para tu empresa</p>
       <button class="cta-button" routerLink="/servicios" (click)="returnToView()">Ver todos los servicios</button>
     </div>
     
     <!-- CTA Container alternativo cuando se muestran todos los servicios -->
-    <div class="cta-container expanded-cta" *ngIf="mostrarServicio()" 
-         data-aos="fade-up" >
+    <div class="cta-container expanded-cta" *ngIf="mostrarServicio()">
       <div class="cta-background-element"></div>
       <h3 class="cta-title">Tecnología de punta al servicio de tu negocio</h3>
       <p class="cta-text">Nuestro equipo de expertos está listo para asesorarte y encontrar la mejor solución a tus necesidades</p>

--- a/src/app/services-overview/services-overview.component.scss
+++ b/src/app/services-overview/services-overview.component.scss
@@ -448,8 +448,7 @@
     .cta-title {
       font-size: 2.2rem;
       margin-bottom: 1.5rem;
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
+      color: var(--text-primary);
       text-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
     }
     

--- a/src/app/services-overview/services-overview.component.scss
+++ b/src/app/services-overview/services-overview.component.scss
@@ -435,8 +435,7 @@
     opacity: 1;
     transform: translateY(0);
     
-    /* Usar animación dedicada para el CTA expandido */
-    animation: fadeInCTA 0.8s ease-out forwards;
+    /* Mostrar el CTA sin animaciones para asegurar visibilidad */
     
     &::before {
       background-image: 
@@ -912,18 +911,7 @@
   opacity: 0.2;
 }
 
-@keyframes fadeInCTA {
-  0% {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* Corregir la animación de los botones del CTA */
+/* Estilos para los botones del CTA */
 .cta-buttons-group {
   display: flex;
   justify-content: center;
@@ -931,24 +919,6 @@
   flex-wrap: wrap;
   
   .cta-button {
-    opacity: 1;
-    transform: translateY(0);
-    /* Añadir animación específica para botones */
-    animation: fadeInButton 0.6s ease-out forwards;
-    animation-delay: 0.3s;
-  }
-  
-  .cta-button.secondary {
-    animation-delay: 0.5s;
-  }
-}
-
-@keyframes fadeInButton {
-  0% {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  100% {
     opacity: 1;
     transform: translateY(0);
   }


### PR DESCRIPTION
## Summary
- remove animations from Services page CTA so the title renders consistently
- strip related CSS keyframes and animation delays

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run lint` *(fails: lint errors in existing services files)*

------
https://chatgpt.com/codex/tasks/task_e_68ae349bf54c833292c81e426326fa42